### PR TITLE
Use global sinon if it's available

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 'use strict'
 
 var Promise = require('native-promise-only')
-var sinon = require('sinon')
+if(global.sinon === undefined){
+  var sinon = require('sinon')
+} else {
+  var sinon = global.sinon
+}
 var createThenable = require('create-thenable')
 
 function resolves (value) {


### PR DESCRIPTION
In some use case sinon is loaded globally (I know this is a bad way of doing thing) and sinon as promised is not returning the right sinon instance.