### PR TITLE
Resolve errors when using with Sinon 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,16 +11,6 @@ function resolves (value) {
 }
 
 sinon.stub.resolves = resolves
-try {
-  var behavior = require('sinon/lib/sinon/behavior')
-  behavior.resolves = resolves
-} catch (e) {
-
-  // If there is no sinon/lib/sinon/behavior we're using sinon 1, set on direct
-  // export
-  sinon.behavior.resolves = resolves
-}
-
 
 function rejects (err) {
   if (typeof err === 'string') {
@@ -32,7 +22,6 @@ function rejects (err) {
 }
 
 sinon.stub.rejects = rejects
-sinon.behavior.rejects = rejects
 
 module.exports = function (_Promise_) {
   if (typeof _Promise_ !== 'function') {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,16 @@ function resolves (value) {
 }
 
 sinon.stub.resolves = resolves
-sinon.behavior.resolves = resolves
+try {
+  var behavior = require('sinon/lib/sinon/behavior')
+  behavior.resolves = resolves
+} catch (e) {
+
+  // If there is no sinon/lib/sinon/behavior we're using sinon 1, set on direct
+  // export
+  sinon.behavior.resolves = resolves
+}
+
 
 function rejects (err) {
   if (typeof err === 'string') {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tape": "^4.0.0"
   },
   "peerDependencies": {
-    "sinon": "1"
+    "sinon": ">=1 <3"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
Sinon 2 (currently in beta) fixes a lot of useful stuff, primarily dealing with its module breakdown so that you can `import sinon from "sinon"` in an ES6-transpiled browser environment such as Webpack or Browserify.

However, the interface has changed a little, and 'behavior' is no longer an exported sinon object, rather it's being treated as internal to the stub module. This patch resolves this by patching behavior internally, in a conditional way so that the module maintains sinon 1 compatibility.