### PR TITLE
Node tests pass based on the test supplied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ If you're using sinon-as-promised in the browser and are not using Browserify/We
 ## Usage
 
 ```js
-var sinon  = require('sinon')
-require('sinon-as-promised')
+var sinon  = require('sinon');
+require('sinon-as-promised');
 
 sinon.stub().resolves('foo')().then(function (value) {
   assert.equal(value, 'foo')
@@ -25,8 +25,8 @@ You'll only need to require sinon-as-promised once. It attaches the appropriate 
 
 ```js
 // Using Bluebird
-var Bluebird = require('bluebird')
-require('sinon-as-promised')(Bluebird)
+var Bluebird = require('bluebird');
+require('sinon-as-promised')(Bluebird);
 ```
 
 ## API

--- a/examples/angular/test.js
+++ b/examples/angular/test.js
@@ -1,30 +1,30 @@
-'use strict'
+'use strict';
 
 /* global describe, beforeEach, it */
 
-var expect = require('chai').expect
-var sinon = require('sinon')
-var sinonAsPromised = require('sinon-as-promised')
-var angular = require('angular')
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var sinonAsPromised = require('sinon-as-promised');
+var angular = require('angular');
 
-require('angular-mocks')
+require('angular-mocks');
 
 describe('sinon-as-promised angular example', function () {
-  var $timeout
+  var $timeout;
   beforeEach(angular.mock.inject(function ($rootScope, $q, _$timeout_) {
-    sinonAsPromised($q)
+    sinonAsPromised($q);
     $timeout = _$timeout_
-  }))
+  }));
 
   it('can create a stub that resolves', function () {
-    var stub = sinon.stub().resolves('value')
+    var stub = sinon.stub().resolves('value');
     var fulfilled = false
     stub().then(function (value) {
       fulfilled = true
       expect(value).to.equal('value')
-    })
-    expect(fulfilled).to.be.false
-    $timeout.flush()
-    expect(fulfilled).to.be.true
+    });
+    expect(fulfilled).to.be.false;
+    $timeout.flush();
+    expect(fulfilled).to.be.true;
   })
-})
+});

--- a/examples/bluebird/test.js
+++ b/examples/bluebird/test.js
@@ -1,18 +1,18 @@
-'use strict'
+'use strict';
 
 /* global describe, it */
 
-var expect = require('chai').expect
-var sinon = require('sinon')
-var Bluebird = require('bluebird')
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var Bluebird = require('bluebird');
 
-require('sinon-as-promised')(Bluebird)
+require('sinon-as-promised')(Bluebird);
 
 describe('sinon-as-promised with ES6', function () {
   it('can create a stub that resolves', function () {
-    var stub = sinon.stub().resolves('value')
+    var stub = sinon.stub().resolves('value');
     return stub().then(function (value) {
       expect(value).to.equal('value')
     })
   })
-})
+});

--- a/examples/node-browserify/test.js
+++ b/examples/node-browserify/test.js
@@ -1,17 +1,17 @@
-'use strict'
+'use strict';
 
 /* global describe, it */
 
-var expect = require('chai').expect
-var sinon = require('sinon')
+var expect = require('chai').expect;
+var sinon = require('sinon');
 
-require('sinon-as-promised')
+require('sinon-as-promised');
 
 describe('sinon-as-promised node example', function () {
   it('can create a stub that resolves', function () {
-    var stub = sinon.stub().resolves('value')
+    var stub = sinon.stub().resolves('value');
     return stub().then(function (value) {
       expect(value).to.equal('value')
     })
   })
-})
+});

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
-'use strict'
+'use strict';
 
-var Promise = require('native-promise-only')
-var sinon = require('sinon')
-var createThenable = require('create-thenable')
+var Promise = require('native-promise-only');
+var sinon = require('sinon');
+sinon.behavior = require('sinon/lib/sinon/behavior');
+
+var createThenable = require('create-thenable');
 
 function resolves (value) {
   return this.returns(createThenable(Promise, function (resolve) {
@@ -10,8 +12,8 @@ function resolves (value) {
   }))
 }
 
-sinon.stub.resolves = resolves
-sinon.behavior.resolves = resolves
+sinon.stub.resolves = resolves;
+sinon.behavior.resolves = resolves;
 
 function rejects (err) {
   if (typeof err === 'string') {
@@ -22,8 +24,8 @@ function rejects (err) {
   }))
 }
 
-sinon.stub.rejects = rejects
-sinon.behavior.rejects = rejects
+sinon.stub.rejects = rejects;
+sinon.behavior.rejects = rejects;
 
 module.exports = function (_Promise_) {
   if (typeof _Promise_ !== 'function') {
@@ -32,4 +34,4 @@ module.exports = function (_Promise_) {
     Promise = _Promise_
   }
   return sinon
-}
+};

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   },
   "devDependencies": {
     "bluebird": "^3.4.1",
-    "sinon": "1",
+    "sinon": "^2.0.0-pre",
     "standard": "^8.0.0",
     "tape": "^4.0.0"
   },
   "peerDependencies": {
-    "sinon": "1"
+    "sinon": "^2.0.0-pre"
   },
   "files": [
     "index.js",

--- a/test.js
+++ b/test.js
@@ -1,74 +1,74 @@
-'use strict'
+'use strict';
 
-var test = require('tape')
-var sinon = require('sinon')
-var Promise = require('native-promise-only')
-var Bluebird = require('bluebird')
-var sinonAsPromised = require('./')
+var test = require('tape');
+var sinon = require('sinon');
+var Promise = require('native-promise-only');
+var Bluebird = require('bluebird');
+var sinonAsPromised = require('./index');
 
 test(function (t) {
   Bluebird.onPossiblyUnhandledRejection(function (err) {
-    t.fail(err)
+    t.fail(err);
     process.exit(1)
-  })
+  });
 
-  t.ok(sinon.stub().resolves()().then() instanceof Promise)
+  t.ok(sinon.stub().resolves()().then() instanceof Promise);
 
-  sinonAsPromised(Bluebird)
-  t.ok(sinon.stub().resolves()().then() instanceof Bluebird)
+  sinonAsPromised(Bluebird);
+  t.ok(sinon.stub().resolves()().then() instanceof Bluebird);
 
-  t.throws(sinonAsPromised, /Promise/, 'requires ctor')
-  t.equal(sinonAsPromised(Bluebird), sinon)
+  t.throws(sinonAsPromised, /Promise/, 'requires ctor');
+  t.equal(sinonAsPromised(Bluebird), sinon);
 
   testStub(3, function (t, stub) {
-    stub.resolves('foo')
-    t.ok('then' in stub.defaultBehavior.returnValue, 'has then method')
+    stub.resolves('foo');
+    t.ok('then' in stub.defaultBehavior.returnValue, 'has then method');
     stub().then(function (value) {
-      t.equal(value, 'foo', 'resolves')
+      t.equal(value, 'foo', 'resolves');
       stub().call('substr', 0, 1).then(function (char) {
         t.equal(char, 'f', 'has proto methods')
       })
     })
-  })
+  });
 
   testStub(2, function (t, stub) {
-    stub.onCall(0).resolves('foo')
-    stub.onCall(1).resolves('bar')
+    stub.onCall(0).resolves('foo');
+    stub.onCall(1).resolves('bar');
     stub().then(function (value) {
-      t.equal(value, 'foo')
+      t.equal(value, 'foo');
       return stub()
     })
     .then(function (value) {
       t.equal(value, 'bar')
     })
-  })
+  });
 
   testStub(1, function (t, stub) {
-    var err = new Error()
-    stub.rejects(err)
+    var err = new Error();
+    stub.rejects(err);
     stub().catch(function (e) {
       t.equal(e, err)
     })
-  })
+  });
 
   testStub(3, function (t, stub) {
-    var err = new Error()
-    stub.onCall(0).rejects(err)
-    stub.onCall(1).rejects('msg')
+    var err = new Error();
+    stub.onCall(0).rejects(err);
+    stub.onCall(1).rejects('msg');
     stub().catch(function (e) {
-      t.equal(e, err)
+      t.equal(e, err);
       return stub()
     })
     .catch(function (err) {
-      t.ok(err instanceof Error)
+      t.ok(err instanceof Error);
       t.equal(err.message, 'msg')
     })
-  })
+  });
 
   function testStub (planned, callback) {
     t.test(function (t) {
-      t.plan(planned)
+      t.plan(planned);
       callback(t, sinon.stub())
     })
   }
-})
+});

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,15 @@
+module.exports = function () {
+  return {
+    files: ['index.js'],
+    tests: ['test.js'],
+    env: {
+      type: 'node',
+      runner: 'node'
+    },
+    testFramework: 'mocha',
+    setup: function (wallaby) {
+      var mocha = wallaby.testFramework;
+      mocha.timeout(200);
+    }
+  }
+};


### PR DESCRIPTION
I don't know if you plan on doing a version to match with 2.x of sinon, but I decided I'd apply what you did with against sinon 2.x. In this on, I only verified against the node,js environment. For me, I'm fighting webpack, wallaby, sinon 2.x pre, and I need yours to play nicely too. 

Hopefully this works for you and others, and most importantly thank you for your time of originally creating this, and sharing it with the community.

Best,
Kelly