### PR TITLE
Added promised spy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ If you're using sinon-as-promised in the browser and are not using Browserify/We
 
 ## Usage
 
+#### Stub
+
 ```js
 var sinon  = require('sinon')
 require('sinon-as-promised')
@@ -20,6 +22,24 @@ sinon.stub().resolves('foo')().then(function (value) {
   assert.equal(value, 'foo')
 })
 ```
+
+#### Spy
+
+```js
+var sinon  = require('sinon')
+require('sinon-as-promised')
+
+var spy = sinon.spy().resolves('foo')
+
+spy.promised('hello', 'world').then(function (value) {
+  assert.equal(value, 'foo')
+})
+
+assert(spy.firstCall.args[0], 'hello')
+assert(spy.firstCall.args[1], 'world')
+```
+
+#### Using Bluebird
 
 You'll only need to require sinon-as-promised once. It attaches the appropriate stubbing functions which will then be available anywhere else you require sinon. It defaults to using native ES6 Promise [(or provides a polyfill)](https://github.com/getify/native-promise-only), but you can use another promise library if you'd like, as long as it exposes a constructor:
 
@@ -30,6 +50,8 @@ require('sinon-as-promised')(Bluebird)
 ```
 
 ## API
+
+### Stub
 
 #### `stub.resolves(value)` -> `stub`
 
@@ -77,6 +99,86 @@ stub.onCall(0).rejects('bar');
 stub().catch(function (error) {
     // error.message === 'bar'
 });
+```
+
+### Spy
+
+#### `spy.resolves(value)` -> `spy` with `promised` function
+
+
+##### value
+
+*Required*  
+Type: `any`
+
+When called, the spy will return a "thenable" object which will return a promise for the provided `value`. Any [Promises/A+](https://promisesaplus.com/) compliant library will handle this object properly.
+
+Unlike stub, spy returns the `Promise` function by the `promised` variable, because the `spy` object should be used to do the spy work(checking calls).   
+
+```js
+var spy = sinon.spy().resolves('foo');
+
+function test(spy) {
+    return spy('hello')
+    .then(function(value) {
+        // value === 'foo'
+        return value    
+    })
+}
+
+test(spy)
+.then(function(value) {
+    // value === 'foo'
+    assert(spy.firstCall.args[0], 'hello')
+})
+```
+---
+
+#### `spy.rejects(err)` -> `spy` with `promised` function
+
+##### err
+
+*Required*  
+Type: `error` / `string`
+
+When called, the stub will return a thenable which will return a reject promise with the provided `err`. If `err` is a string, it will be set as the message on an `Error` object.
+
+Unlike stub, spy returns the `Promise` function by the `promised` variable, because the `spy` object should be used to do the spy work(checking calls).
+
+```js
+// Example with string
+var spy = sinon.spy().rejects('foo');
+
+function test(spy) {
+    return spy('hello')
+    .catch(function(err) {
+        // err === 'foo'
+        return 'baz'    
+    })
+}
+
+test(spy)
+.then(function(value) {
+    // value === 'baz'
+    assert(spy.firstCall.args[0], 'hello')
+})
+
+// Example with Error object
+var spy2 = sinon.spy().rejects(new Error('bar'))
+
+function test(spy) {
+    return spy('world')
+    .catch(function(err) {
+        // err.message === 'bar'
+        return 'xab'    
+    })
+}
+
+test(spy2)
+.then(function(value) {
+    // value === 'xab'
+    assert(spy2.firstCall.args[0], 'world')
+})
 ```
 
 ## Examples

--- a/index.js
+++ b/index.js
@@ -25,6 +25,32 @@ function rejects (err) {
 sinon.stub.rejects = rejects
 sinon.behavior.rejects = rejects
 
+function spyResolves(val) {
+  var spy = this
+  spy.promised = function() {
+    spy.apply(this, arguments)
+    return createThenable(Promise, function (resolve) {
+      resolve(val)
+    })
+  }
+  return spy
+}
+
+sinon.spy.resolves = spyResolves
+
+function spyRejects(err) {
+  var spy = this
+  spy.promised = function() {
+    spy.apply(this, arguments)
+    return createThenable(Promise, function (resolve, reject) {
+      reject(err)
+    })
+  }
+  return spy
+}
+
+sinon.spy.rejects = spyRejects
+
 module.exports = function (_Promise_) {
   if (typeof _Promise_ !== 'function') {
     throw new Error('A Promise constructor must be provided')

--- a/index.js
+++ b/index.js
@@ -25,9 +25,9 @@ function rejects (err) {
 sinon.stub.rejects = rejects
 sinon.behavior.rejects = rejects
 
-function spyResolves(val) {
+function spyResolves (val) {
   var spy = this
-  spy.promised = function() {
+  spy.promised = function () {
     spy.apply(this, arguments)
     return createThenable(Promise, function (resolve) {
       resolve(val)
@@ -38,9 +38,9 @@ function spyResolves(val) {
 
 sinon.spy.resolves = spyResolves
 
-function spyRejects(err) {
+function spyRejects (err) {
   var spy = this
-  spy.promised = function() {
+  spy.promised = function () {
     spy.apply(this, arguments)
     return createThenable(Promise, function (resolve, reject) {
       reject(err)

--- a/test.js
+++ b/test.js
@@ -99,9 +99,9 @@ test(function (t) {
   })
 
   testSpy(4, function (t, spy) {
-    function test(s) {
+    function test (s) {
       return s('hello', 'world')
-      .then(function(value){
+      .then(function (value) {
         t.equal(value, 'foo')
         return 'bar'
       })
@@ -109,7 +109,7 @@ test(function (t) {
 
     var s = spy.resolves('foo')
     test(s.promised)
-    .then(function(value){
+    .then(function (value) {
       t.equal(value, 'bar')
       t.equal(s.firstCall.args[0], 'hello')
       t.equal(s.firstCall.args[1], 'world')
@@ -117,9 +117,9 @@ test(function (t) {
   })
 
   testSpy(4, function (t, spy) {
-    function test(s) {
+    function test (s) {
       return s('hello', 'world')
-      .catch(function(value){
+      .catch(function (value) {
         t.equal(value, 'foo')
         return 'bar'
       })
@@ -127,7 +127,7 @@ test(function (t) {
 
     var s = spy.rejects('foo')
     test(s.promised)
-    .then(function(value){
+    .then(function (value) {
       t.equal(value, 'bar')
       t.equal(s.firstCall.args[0], 'hello')
       t.equal(s.firstCall.args[1], 'world')
@@ -136,9 +136,9 @@ test(function (t) {
 
   testSpy(4, function (t, spy) {
     var err = new Error()
-    function test(s) {
+    function test (s) {
       return s('hello', 'world')
-      .catch(function(e){
+      .catch(function (e) {
         t.equal(e, err)
         return 'bar'
       })
@@ -146,7 +146,7 @@ test(function (t) {
 
     var s = spy.rejects(err)
     test(s.promised)
-    .then(function(value){
+    .then(function (value) {
       t.equal(value, 'bar')
       t.equal(s.firstCall.args[0], 'hello')
       t.equal(s.firstCall.args[1], 'world')

--- a/test.js
+++ b/test.js
@@ -72,3 +72,91 @@ test(function (t) {
     })
   }
 })
+
+test(function (t) {
+  Bluebird.onPossiblyUnhandledRejection(function (err) {
+    t.fail(err)
+    process.exit(1)
+  })
+
+  t.equal(sinon.spy().resolves().promised().then().constructor.name, "Promise")
+
+  sinonAsPromised(Bluebird)
+  t.ok(sinon.spy().resolves().promised().then() instanceof Bluebird)
+
+  t.throws(sinonAsPromised, /Promise/, 'requires ctor')
+  t.equal(sinonAsPromised(Bluebird), sinon)
+
+  testSpy(3, function (t, spy) {
+    var s = spy.resolves('foo')
+    t.ok('then' in s.promised(), 'has then method')
+    spy.promised().then(function (value) {
+      t.equal(value, 'foo', 'resolves')
+      spy.promised().call('substr', 0, 1).then(function (char) {
+        t.equal(char, 'f', 'has proto methods')
+      })
+    })
+  })
+
+  testSpy(4, function (t, spy) {
+    function test(s) {
+      return s('hello', 'world')
+      .then(function(value){
+        t.equal(value, 'foo')
+        return 'bar'
+      })
+    }
+
+    var s = spy.resolves('foo')
+    test(s.promised)
+    .then(function(value){
+      t.equal(value, 'bar')
+      t.equal(s.firstCall.args[0], 'hello')
+      t.equal(s.firstCall.args[1], 'world')
+    })
+  })
+
+  testSpy(4, function (t, spy) {
+    function test(s) {
+      return s('hello', 'world')
+      .catch(function(value){
+        t.equal(value, 'foo')
+        return 'bar'
+      })
+    }
+
+    var s = spy.rejects('foo')
+    test(s.promised)
+    .then(function(value){
+      t.equal(value, 'bar')
+      t.equal(s.firstCall.args[0], 'hello')
+      t.equal(s.firstCall.args[1], 'world')
+    })
+  })
+
+  testSpy(4, function (t, spy) {
+    var err = new Error()
+    function test(s) {
+      return s('hello', 'world')
+      .catch(function(e){
+        t.equal(e, err)
+        return 'bar'
+      })
+    }
+
+    var s = spy.rejects(err)
+    test(s.promised)
+    .then(function(value){
+      t.equal(value, 'bar')
+      t.equal(s.firstCall.args[0], 'hello')
+      t.equal(s.firstCall.args[1], 'world')
+    })
+  })
+
+  function testSpy (planned, callback) {
+    t.test(function (t) {
+      t.plan(planned)
+      callback(t, sinon.spy())
+    })
+  }
+})

--- a/test.js
+++ b/test.js
@@ -79,7 +79,7 @@ test(function (t) {
     process.exit(1)
   })
 
-  t.equal(sinon.spy().resolves().promised().then().constructor.name, "Promise")
+  t.equal(sinon.spy().resolves().promised().then().constructor.name, 'Promise')
 
   sinonAsPromised(Bluebird)
   t.ok(sinon.spy().resolves().promised().then() instanceof Bluebird)


### PR DESCRIPTION
When I was testing `fetch` in `isomorphic-fetch` module, I needed a promised spy. Sadly, there was no library that supports that feature. 

So, I created one and added to `sinon-as-promised`. I hope you like it. 